### PR TITLE
auth() can note be called before connect()

### DIFF
--- a/extensions/data/source/Redis.php
+++ b/extensions/data/source/Redis.php
@@ -108,7 +108,6 @@ class Redis extends \lithium\data\Source {
 			}
 
 		} catch (RedisException $e) {
-            var_dump($e); die();
 			throw new NetworkException("Could not connect to the database.", 503, $e);
 		}
 


### PR DESCRIPTION
auth is a redis-command which needs a working connection.
